### PR TITLE
Refactor to support map of promises for loading data

### DIFF
--- a/src/client.es6.js
+++ b/src/client.es6.js
@@ -58,14 +58,14 @@ class ClientReactApp extends ClientApp {
       ctx.props = this.getState();
     }
 
-    return new Promise(function(resolve) {
-      this.route(ctx).then(function() {
+    return new Promise((resolve) => {
+      this.route(ctx).then(() => {
         if (ctx.body && typeof ctx.body === 'function') {
           this.emitter.once('page:update', resolve);
           React.render(ctx.body(ctx.props), mountPoint);
         }
-      }.bind(this));
-    }.bind(this));
+      });
+    });
   }
 }
 

--- a/src/client.es6.js
+++ b/src/client.es6.js
@@ -60,8 +60,10 @@ class ClientReactApp extends ClientApp {
 
     return new Promise(function(resolve) {
       this.route(ctx).then(function() {
-        this.emitter.once('page:update', resolve);
-        React.render(ctx.body, mountPoint);
+        if (ctx.body && typeof ctx.body === 'function') {
+          this.emitter.once('page:update', resolve);
+          React.render(ctx.body(ctx.props), mountPoint);
+        }
       }.bind(this));
     }.bind(this));
   }

--- a/src/server.es6.js
+++ b/src/server.es6.js
@@ -2,20 +2,26 @@ import React from 'react';
 import { App } from 'horse';
 
 class ServerReactApp extends App {
-  * injectBootstrap () {
-    var p = this.props;
+  injectBootstrap (format) {
+    return function * () {
+      var p = Object.assign({}, this.props);
 
-    delete p.app;
-    delete p.api;
-    delete p.manifest;
-    p.data = {};
+      if (format) {
+        p = format(p);
+      }
 
-    var bootstrap = ServerReactApp.safeStringify(p);
+      delete p.app;
+      delete p.api;
+      delete p.manifest;
+      p.data = {};
 
-    var body = this.body;
-    var bodyIndex = body.lastIndexOf('</body>');
-    var template = `<script>var bootstrap=${bootstrap}</script>`;
-    this.body = body.slice(0, bodyIndex) + template + body.slice(bodyIndex);
+      var bootstrap = ServerReactApp.safeStringify(p);
+
+      var body = this.body;
+      var bodyIndex = body.lastIndexOf('</body>');
+      var template = `<script>var bootstrap=${bootstrap}</script>`;
+      this.body = body.slice(0, bodyIndex) + template + body.slice(bodyIndex);
+    }
   }
 
   * render () {
@@ -94,7 +100,7 @@ class ServerReactApp extends App {
           this.props = formatProps(this.props);
         }
 
-        yield app.injectBootstrap;
+        yield app.injectBootstrap(app.config.formatBootstrap);
       }
     }
   }


### PR DESCRIPTION
Breaking changes:
- `context.body` is now a function that takes one parameter, `props`.
  This allows properties to be asynchronously loaded, and the body to be
  instantiated once asynchronous properties have resolved.
- `context.props.data` is now a map of keys/promises. The server will
  wait for all promises to resolve before rendering the body. Previously,
  routes would `yield` promise results. This change allows the client side
  to asynchronously render components as data resolves, rather than
  waiting for all data to resolve before rendering.

Will be a major version change (v1.0.0).

:eyeglasses: @curioussavage and @dwick 
