### PR TITLE
Add server pre-render method

### DIFF
--- a/src/server.es6.js
+++ b/src/server.es6.js
@@ -104,6 +104,15 @@ class ServerReactApp extends App {
           }
         }
 
+        if (this.preServerRender) {
+          const preServerRender = this.preServerRender(this);
+
+          // If you explicitly return `false`, don't continue the render.
+          if (preServerRender === false) {
+            return;
+          }
+        }
+
         var renderStart = Date.now();
         yield app.render;
         this.timings.render = Date.now() - renderStart;


### PR DESCRIPTION
This is useful if you need to verify the data returned by API calls
_before_ the render call is run. If `false` is explicitly returned by
the function, then the render is not run.

:eyeglasses: @schwers
